### PR TITLE
Fix checkForErrorStatus reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ class User extends React.PureComponent {
     }
   }
 
-  checkForFetchError = (state, context) => context.status !== 200;
+  checkForFetchError = (state, { data }) => data.status !== 200;
 
   setUserDataFetchError = (state) => {
     // This function will tell Sunfish to skip any subsequent steps


### PR DESCRIPTION
Really like the idea and implementation of the library!

I believe the `.status` field would appear on the `.data` property of the passed in `context` argument for the `checkForErrorStatus` method.

 Followed the rest of the code style and utilized destructuring on `context` to fix the status check.